### PR TITLE
Restructure Cache Document

### DIFF
--- a/lib/mongoid_cacheable.rb
+++ b/lib/mongoid_cacheable.rb
@@ -12,8 +12,6 @@ module Mongoid
         cached_name = "cached_#{name}"
         clear_cached_name = "clear_cached_#{name}"
 
-        field field_name, *options
-
         define_method(cached_name) do
           cache_field(field_name, &method(name))
         end

--- a/lib/mongoid_cacheable.rb
+++ b/lib/mongoid_cacheable.rb
@@ -1,10 +1,16 @@
 require "active_support"
 require "mongoid"
+require "mongoid_cacheable/cache"
 require "mongoid_cacheable/version"
 
 module Mongoid
   module Cacheable
     extend ActiveSupport::Concern
+
+    included do
+      after_initialize -> { build_cached unless cached }
+      embeds_one :cached, as: :cacheable, class_name: "Cache"
+    end
 
     module ClassMethods
       def cache( name, *options )
@@ -23,16 +29,16 @@ module Mongoid
     end
 
     def cache_field(field_name, &block)
-      unless read_attribute(field_name)
+      unless cached.read_attribute(field_name)
         # cache quitely with atomic set
-        set field_name, yield
+        cached.set field_name, yield
       end
 
-      read_attribute(field_name)
+      cached.read_attribute(field_name)
     end
 
     def clear_cache_field(field_name)
-      unset field_name
+      cached.unset field_name
     end
   end
 end

--- a/lib/mongoid_cacheable/cache.rb
+++ b/lib/mongoid_cacheable/cache.rb
@@ -1,0 +1,4 @@
+class Cache
+  include Mongoid::Document
+  embedded_in :cacheable, polymorphic: true
+end

--- a/spec/mongoid_cacheable_spec.rb
+++ b/spec/mongoid_cacheable_spec.rb
@@ -18,12 +18,12 @@ describe Mongoid::Cacheable do
   end
 
   it "caches a method's result" do
-    book.read_attribute(:_abc).should_not be_nil
+    book.cached.read_attribute(:_abc).should_not be_nil
   end
 
   it "clears a cache result" do
     book.clear_cache_field(:_abc)
-    book.read_attribute(:_abc).should be_nil
+    book.cached.read_attribute(:_abc).should be_nil
   end
 
   it "caches wihtout saving the parent" do


### PR DESCRIPTION
A cache on an document adds a lot of additional methods and fields. More than necessary even. I think there would be some benefit to updating the structure to reflect a more embedded style of cache.
